### PR TITLE
add current_set_app for MatchInfo

### DIFF
--- a/aiohttp_traversal/router.py
+++ b/aiohttp_traversal/router.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import sys
 import types
+from contextlib import contextmanager
 
 from aiohttp.abc import AbstractRouter, AbstractMatchInfo
 from aiohttp.web_exceptions import HTTPNotFound
@@ -29,6 +30,7 @@ class ViewNotResolved(Exception):
 
 class BaseMatchInfo(AbstractMatchInfo):
     route = None
+    _current_app = None
 
     def __init__(self):
         self._apps = []
@@ -50,6 +52,18 @@ class BaseMatchInfo(AbstractMatchInfo):
 
     def freeze(self):
         pass
+    
+    @contextmanager
+    def set_current_app(self, app):
+        assert app in self._apps, (
+            "Expected one of the following apps {!r}, got {!r}"
+            .format(self._apps, app))
+        prev = self._current_app
+        self._current_app = app
+        try:
+            yield
+        finally:
+            self._current_app = prev
 
 
 class MatchInfo(BaseMatchInfo):


### PR DESCRIPTION
При попытке воспроизвести пример из https://github.com/zzzsochi/aiohttp_traversal/blob/master/examples/1-hello.py
Возникает вот такая ошибка.

```
Traceback (most recent call last):
File "/usr/local/lib/python3.6/site-packages/aiohttp/web_protocol.py", line 410, in start
resp = yield from self._request_handler(request)
File "/usr/local/lib/python3.6/site-packages/aiohttp/web.py", line 325, in _handle
resp = yield from handler(request)
File "/usr/local/lib/python3.6/site-packages/aiohttp/web_middlewares.py", line 92, in impl
 with request.match_info.set_current_app(app):
AttributeError: 'MatchInfo' object has no attribute 'set_current_app'
```

Я в MatchInfo добавил вот этот метод
https://github.com/aio-libs/aiohttp/blob/c178a99c871cb93afe641d2f654a35bdec1c466d/aiohttp/web_urldispatcher.py#L215

И все заработало.
